### PR TITLE
Fix storing of presets not working for older camera models

### DIFF
--- a/index.js
+++ b/index.js
@@ -534,7 +534,13 @@ class instance extends instance_skel {
 				break;
 
 			case 'savePset':
-				cmd = 'camera preset store ' + opt.val + ' ' + opt.speed + (opt.ccu === true ? ' save-ccu' : '');
+				cmd = 'camera preset store ' + opt.val;
+				if (!this.config.storeWithoutSpeed) {
+					cmd += ' ' + opt.speed;
+				}
+				if (opt.ccu === true) {
+					cmd += ' save-ccu';
+				}
 				this.sendCommand(cmd);
 				break;
 			case 'recallPset':
@@ -622,7 +628,14 @@ class instance extends instance_skel {
 				max: 999,
 				default: 5,
 				required: true
-			}
+			},
+			{
+				type: 'checkbox',
+				id: 'storeWithoutSpeed',
+				label: 'Store presets without setting any speed. Useful for older models/firmware not supporting it.',
+				width: 2,
+				default: false
+			},
 		]
 	}
 

--- a/index.js
+++ b/index.js
@@ -633,7 +633,7 @@ class instance extends instance_skel {
 				type: 'checkbox',
 				id: 'storeWithoutSpeed',
 				label: 'Store presets without setting any speed. Useful for older models/firmware not supporting it.',
-				width: 2,
+				width: 4,
 				default: false
 			},
 		]


### PR DESCRIPTION
This PR introduces a setting "storeWithoutSpeed" which addresses a problem of older camera models like ConferenceShot 10 that we use. This camera model does not support the last parameter "speed" to be present if it is the save-preset function does not work.

The "storeWithoutSpeed"-setting is used in the savePset branch of actions and just skips adding it to the command string.